### PR TITLE
Rebase master

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,10 +38,10 @@ sh -c "git push mirror $branch"
 sleep $POLL_TIMEOUT
 
 pipeline_id=$(curl --header "PRIVATE-TOKEN: $GITLAB_PASSWORD" --silent "https://${GITLAB_HOSTNAME}/api/v4/projects/${GITLAB_PROJECT_ID}/repository/commits/${branch}" | jq '.last_pipeline.id')
-echo "******* Pipeline URL: $*/-/pipelines/${pipeline_id} *******"
 
 echo "Triggered CI for branch ${branch}"
 echo "Working with pipeline id #${pipeline_id}"
+echo "Pipeline URL: $*/-/pipelines/${pipeline_id}"
 echo "Poll timeout set to ${POLL_TIMEOUT}"
 
 ci_status="pending"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ sh -c "git push mirror $branch"
 sleep $POLL_TIMEOUT
 
 pipeline_id=$(curl --header "PRIVATE-TOKEN: $GITLAB_PASSWORD" --silent "https://${GITLAB_HOSTNAME}/api/v4/projects/${GITLAB_PROJECT_ID}/repository/commits/${branch}" | jq '.last_pipeline.id')
+echo "******* Pipeline URL: $*/-/pipelines/${pipeline_id} *******"
 
 echo "Triggered CI for branch ${branch}"
 echo "Working with pipeline id #${pipeline_id}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,12 @@ POLL_TIMEOUT=${POLL_TIMEOUT:-$DEFAULT_POLL_TIMEOUT}
 DEFAULT_GITHUB_REF=${GITHUB_REF:11}
 git checkout "${CHECKOUT_BRANCH:-$DEFAULT_GITHUB_REF}"
 
+sh -c "git config --global user.name $GITLAB_USERNAME"
+sh -c "git config --global user.email ${GITLAB_USERNAME}@${GITLAB_HOSTNAME}"
+if [[ -n "${REBASE_MASTER}" ]] && [[ "${REBASE_MASTER}" == "true" ]]; then # Check if variable exists and is true
+    git rebase origin/master
+fi
+
 branch=$(git symbolic-ref --short HEAD)
 
 sh -c "git config --global credential.username $GITLAB_USERNAME"


### PR DESCRIPTION
This PR adds a variable, `REBASE_MASTER`, that turns on automatic rebasing with origin/master. This is useful for checking the mergeability of a target branch and for making sure that all the code, including that related to the CI tests, is up-to-date.

I also added a print out of the URL for the pipeline after it is created, which I find useful and which has been requested by others.

The variable seems to work as expected. With it enabled, here is an example of the automatic rebasing failing:
https://github.com/cms-L1TK/firmware-hls/runs/2510013025?check_suite_focus=true
In this case, the user would then have to manually take care of conflicts. And here is an example after manually resolving conflicts:
https://github.com/cms-L1TK/firmware-hls/runs/2510126300?check_suite_focus=true